### PR TITLE
fix issue #1 warning of conversion into to string

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Set swappiness
   ansible.posix.sysctl:
     name: vm.swappiness
-    value: "{{ swap_swappiness }}"
+    value: "{{ swap_swappiness | string }}"
     state: present
 
 - block:


### PR DESCRIPTION
* Before
```
TASK [swap : Set swappiness] *****************************************************************************************************************************************************************
[WARNING]: The value "60" (type int) was converted to "'60'" (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.
ok: [mx1]
```

* After
```
TASK [swap : Set swappiness] *****************************************************************************************************************************************************************
ok: [mx1]
```

---
name: Pull request
about: Fix warning of the conversion of integer to string

---

**Describe the change**
explicite convert to string instead of implicite convertion

**Testing**
In case a feature was added, how were tests performed?
* Before
```
TASK [swap : Set swappiness] *****************************************************************************************************************************************************************
[WARNING]: The value "60" (type int) was converted to "'60'" (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.
ok: [mx1]
```

* After
```
TASK [swap : Set swappiness] *****************************************************************************************************************************************************************
ok: [mx1]
```
